### PR TITLE
added GUI support + cleanup

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -11,6 +11,7 @@
 #include "Emu/Cell/Modules/cellSysutil.h"
 #include "Emu/Cell/Modules/cellUserInfo.h"
 #include "Emu/RSX/Overlays/overlay_message.h"
+#include "Emu/system_config.h"
 
 #include "cellSaveData.h"
 #include "cellMsgDialog.h"
@@ -1752,11 +1753,12 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 	fileGet->excSize = 0;
 
 	// show indicator for automatic save or auto load interactions if the game requests it (statSet->indicator)
-	const bool show_auto_indicator = operation <= SAVEDATA_OP_LIST_AUTO_LOAD && statSet && statSet->indicator;
+	const bool show_auto_indicator = operation <= SAVEDATA_OP_LIST_AUTO_LOAD && statSet && statSet->indicator && g_cfg.misc.show_autosave_autoload_hint;
 
 	if (show_auto_indicator)
 	{
 		auto msg_text = localized_string_id::INVALID;
+
 		if (operation == SAVEDATA_OP_AUTO_SAVE || operation == SAVEDATA_OP_LIST_AUTO_SAVE)
 		{
 			msg_text = localized_string_id::CELL_SAVEDATA_AUTOSAVE;
@@ -1766,22 +1768,22 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 			msg_text = localized_string_id::CELL_SAVEDATA_AUTOLOAD;
 		}
 
-		u32 indicator_pos = (statSet->indicator->dispPosition & 0x0F);
+		auto msg_location = rsx::overlays::message_pin_location::top_left;
 
-		auto msg_location = rsx::overlays::message_pin_location::top;
-		switch (indicator_pos)
+		switch (statSet->indicator->dispPosition & 0x0F)
 		{
-		case CELL_SAVEDATA_INDICATORPOS_UPPER_LEFT:
-			msg_location = rsx::overlays::message_pin_location::top;
+		case CELL_SAVEDATA_INDICATORPOS_LOWER_RIGHT:
+			msg_location = rsx::overlays::message_pin_location::bottom_right;
 			break;
 		case CELL_SAVEDATA_INDICATORPOS_LOWER_LEFT:
-			msg_location = rsx::overlays::message_pin_location::bottom;
+			msg_location = rsx::overlays::message_pin_location::bottom_left;
 			break;
 		case CELL_SAVEDATA_INDICATORPOS_UPPER_RIGHT:
 			msg_location = rsx::overlays::message_pin_location::top_right;
 			break;
-		case CELL_SAVEDATA_INDICATORPOS_LOWER_RIGHT:
-			msg_location = rsx::overlays::message_pin_location::bottom_right;
+		case CELL_SAVEDATA_INDICATORPOS_UPPER_LEFT:
+		default:
+			msg_location = rsx::overlays::message_pin_location::top_left;
 			break;
 		}
 

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_settings.cpp
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_settings.cpp
@@ -95,6 +95,7 @@ namespace rsx
 			add_checkbox(&g_cfg.misc.show_trophy_popups, "Show Trophy Popups");
 			add_checkbox(&g_cfg.misc.show_shader_compilation_hint, "Show Shader Compilation Hint");
 			add_checkbox(&g_cfg.misc.show_ppu_compilation_hint, "Show PPU Compilation Hint");
+			add_checkbox(&g_cfg.misc.show_autosave_autoload_hint, "Show Autosave/Autoload Hint");
 
 			apply_layout();
 		}

--- a/rpcs3/Emu/RSX/Overlays/overlay_compile_notification.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_compile_notification.cpp
@@ -22,7 +22,7 @@ namespace rsx
 				localized_string_id::RSX_OVERLAYS_COMPILING_SHADERS,
 				5'000'000,
 				{},
-				message_pin_location::bottom,
+				message_pin_location::bottom_left,
 				s_shader_loading_icon24,
 				true);
 		}
@@ -41,7 +41,7 @@ namespace rsx
 				localized_string_id::RSX_OVERLAYS_COMPILING_PPU_MODULES,
 				20'000'000,
 				refs,
-				message_pin_location::bottom,
+				message_pin_location::bottom_left,
 				s_ppu_loading_icon24,
 				true);
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_message.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message.cpp
@@ -197,30 +197,31 @@ namespace rsx
 
 			// Render reversed list. Oldest entries are furthest from the border
 			constexpr u16 spacing = 4;
-			s16 y_offset = 8;
 			s16 x_offset = 10;
+			s16 y_offset = 8;
 			usz index = 0;
+
 			for (auto it = vis_set.rbegin(); it != vis_set.rend(); ++it, ++index)
 			{
-				if (origin == message_pin_location::top) [[ likely ]]
+				switch (origin)
 				{
-					it->update(index, cur_time, x_offset, y_offset);
-					y_offset += (spacing + it->h);
-				}
-				else if (origin == message_pin_location::bottom)
-				{
-					y_offset += (spacing + it->h);
-					it->update(index, cur_time, x_offset, virtual_height - y_offset);
-				}
-				else if (origin == message_pin_location::top_right)
-				{
-					it->update(index, cur_time, virtual_width - x_offset - it->w, y_offset);
-					y_offset += (spacing + it->h);
-				}
-				else if (origin == message_pin_location::bottom_right)
-				{
+				case message_pin_location::bottom_right:
 					y_offset += (spacing + it->h);
 					it->update(index, cur_time, virtual_width - x_offset - it->w, virtual_height - y_offset);
+					break;
+				case message_pin_location::bottom_left:
+					y_offset += (spacing + it->h);
+					it->update(index, cur_time, x_offset, virtual_height - y_offset);
+					break;
+				case message_pin_location::top_right:
+					it->update(index, cur_time, virtual_width - x_offset - it->w, y_offset);
+					y_offset += (spacing + it->h);
+					break;
+				case message_pin_location::top_left:
+				default:
+					it->update(index, cur_time, x_offset, y_offset);
+					y_offset += (spacing + it->h);
+					break;
 				}
 			}
 		}
@@ -234,13 +235,13 @@ namespace rsx
 
 			std::lock_guard lock(m_mutex_queue);
 
-			update_queue(m_visible_items_top, m_ready_queue_top, message_pin_location::top);
-			update_queue(m_visible_items_bottom, m_ready_queue_bottom, message_pin_location::bottom);
-			update_queue(m_visible_items_top_right, m_ready_queue_top_right, message_pin_location::top_right);
 			update_queue(m_visible_items_bottom_right, m_ready_queue_bottom_right, message_pin_location::bottom_right);
+			update_queue(m_visible_items_bottom_left, m_ready_queue_bottom_left, message_pin_location::bottom_left);
+			update_queue(m_visible_items_top_right, m_ready_queue_top_right, message_pin_location::top_right);
+			update_queue(m_visible_items_top_left, m_ready_queue_top_left, message_pin_location::top_left);
 
-			visible = !m_visible_items_top.empty() || !m_visible_items_bottom.empty() ||
-			          !m_visible_items_top_right.empty() || !m_visible_items_bottom_right.empty();
+			visible = !m_visible_items_bottom_right.empty() || !m_visible_items_bottom_left.empty() ||
+			          !m_visible_items_top_right.empty() || !m_visible_items_top_left.empty();
 		}
 
 		compiled_resource message::get_compiled()
@@ -254,12 +255,12 @@ namespace rsx
 
 			compiled_resource cr{};
 
-			for (auto& item : m_visible_items_top)
+			for (auto& item : m_visible_items_bottom_right)
 			{
 				cr.add(item.get_compiled());
 			}
 
-			for (auto& item : m_visible_items_bottom)
+			for (auto& item : m_visible_items_bottom_left)
 			{
 				cr.add(item.get_compiled());
 			}
@@ -269,7 +270,7 @@ namespace rsx
 				cr.add(item.get_compiled());
 			}
 
-			for (auto& item : m_visible_items_bottom_right)
+			for (auto& item : m_visible_items_top_left)
 			{
 				cr.add(item.get_compiled());
 			}
@@ -307,14 +308,15 @@ namespace rsx
 
 			switch (location)
 			{
-			case message_pin_location::top:
-				return check_list(m_ready_queue_top) || check_list(m_visible_items_top);
-			case message_pin_location::bottom:
-				return check_list(m_ready_queue_bottom) || check_list(m_visible_items_bottom);
-			case message_pin_location::top_right:
-				return check_list(m_ready_queue_top_right) || check_list(m_visible_items_top_right);
 			case message_pin_location::bottom_right:
 				return check_list(m_ready_queue_bottom_right) || check_list(m_visible_items_bottom_right);
+			case message_pin_location::bottom_left:
+				return check_list(m_ready_queue_bottom_left) || check_list(m_visible_items_bottom_left);
+			case message_pin_location::top_right:
+				return check_list(m_ready_queue_top_right) || check_list(m_visible_items_top_right);
+			case message_pin_location::top_left:
+			default:
+				return check_list(m_ready_queue_top_left) || check_list(m_visible_items_top_left);
 			}
 
 			return false;

--- a/rpcs3/Emu/RSX/Overlays/overlay_message.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message.h
@@ -11,10 +11,10 @@ namespace rsx
 	{
 		enum class message_pin_location
 		{
-			top,
-			bottom,
+			bottom_right,
+			bottom_left,
 			top_right,
-			bottom_right
+			top_left
 		};
 
 		class message_item : public rounded_rect
@@ -57,27 +57,28 @@ namespace rsx
 				T msg_id,
 				u64 expiration,
 				std::shared_ptr<atomic_t<u32>> refs,
-				message_pin_location location = message_pin_location::top,
+				message_pin_location location = message_pin_location::top_left,
 				std::shared_ptr<overlay_element> icon = {},
 				bool allow_refresh = false)
 			{
 				std::lock_guard lock(m_mutex_queue);
 
-				auto* queue = &m_ready_queue_top;
+				auto* queue = &m_ready_queue_top_left;
 
 				switch (location)
 				{
-				case message_pin_location::top:
-					queue = &m_ready_queue_top;
+				case message_pin_location::bottom_right:
+					queue = &m_ready_queue_bottom_right;
 					break;
-				case message_pin_location::bottom:
-					queue = &m_ready_queue_bottom;
+				case message_pin_location::bottom_left:
+					queue = &m_ready_queue_bottom_left;
 					break;
 				case message_pin_location::top_right:
 					queue = &m_ready_queue_top_right;
 					break;
-				case message_pin_location::bottom_right:
-					queue = &m_ready_queue_bottom_right;
+				case message_pin_location::top_left:
+				default:
+					queue = &m_ready_queue_top_left;
 					break;
 				}
 
@@ -105,16 +106,16 @@ namespace rsx
 			shared_mutex m_mutex_queue;
 
 			// Top and bottom enqueued sets
-			std::deque<message_item> m_ready_queue_top;
-			std::deque<message_item> m_ready_queue_bottom;
-			std::deque<message_item> m_ready_queue_top_right;
 			std::deque<message_item> m_ready_queue_bottom_right;
+			std::deque<message_item> m_ready_queue_bottom_left;
+			std::deque<message_item> m_ready_queue_top_right;
+			std::deque<message_item> m_ready_queue_top_left;
 
 			// Top and bottom visible sets
-			std::deque<message_item> m_visible_items_top;
-			std::deque<message_item> m_visible_items_bottom;
-			std::deque<message_item> m_visible_items_top_right;
 			std::deque<message_item> m_visible_items_bottom_right;
+			std::deque<message_item> m_visible_items_bottom_left;
+			std::deque<message_item> m_visible_items_top_right;
+			std::deque<message_item> m_visible_items_top_left;
 
 			void update_queue(std::deque<message_item>& vis_set, std::deque<message_item>& ready_set, message_pin_location origin);
 
@@ -129,7 +130,7 @@ namespace rsx
 			T msg_id,
 			u64 expiration = 5'000'000,
 			std::shared_ptr<atomic_t<u32>> refs = {},
-			message_pin_location location = message_pin_location::top,
+			message_pin_location location = message_pin_location::top_left,
 			std::shared_ptr<overlay_element> icon = {},
 			bool allow_refresh = false)
 		{

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -340,6 +340,7 @@ struct cfg_root : cfg::node
 		cfg::_bool show_trophy_popups{ this, "Show trophy popups", true, true };
 		cfg::_bool show_shader_compilation_hint{ this, "Show shader compilation hint", true, true };
 		cfg::_bool show_ppu_compilation_hint{ this, "Show PPU compilation hint", true, true };
+		cfg::_bool show_autosave_autoload_hint{ this, "Show autosave/autoload hint", false, true };
 		cfg::_bool use_native_interface{ this, "Use native user interface", true };
 		cfg::string gdb_server{ this, "GDB Server", "127.0.0.1:2345" };
 		cfg::_bool silence_all_logs{ this, "Silence All Logs", false, true };

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -174,6 +174,7 @@ enum class emu_settings_type
 	UseNativeInterface,
 	ShowShaderCompilationHint,
 	ShowPPUCompilationHint,
+	ShowAutosaveAutoloadHint,
 	WindowTitleFormat,
 	PauseDuringHomeMenu,
 
@@ -363,6 +364,7 @@ inline static const QMap<emu_settings_type, cfg_location> settings_location =
 	{ emu_settings_type::UseNativeInterface,        { "Miscellaneous", "Use native user interface"}},
 	{ emu_settings_type::ShowShaderCompilationHint, { "Miscellaneous", "Show shader compilation hint"}},
 	{ emu_settings_type::ShowPPUCompilationHint,    { "Miscellaneous", "Show PPU compilation hint"}},
+	{ emu_settings_type::ShowAutosaveAutoloadHint,  { "Miscellaneous", "Show autosave/autoload hint"}},
 	{ emu_settings_type::SilenceAllLogs,            { "Miscellaneous", "Silence All Logs" }},
 	{ emu_settings_type::WindowTitleFormat,         { "Miscellaneous", "Window Title Format" }},
 	{ emu_settings_type::PauseDuringHomeMenu,       { "Miscellaneous", "Pause Emulation During Home Menu" }},

--- a/rpcs3/rpcs3qt/localized_emu.h
+++ b/rpcs3/rpcs3qt/localized_emu.h
@@ -159,8 +159,8 @@ private:
 		case localized_string_id::CELL_SAVEDATA_DELETE: return tr("Delete this data?\n\n%0", "Savedata entry info").arg(std::forward<Args>(args)...);
 		case localized_string_id::CELL_SAVEDATA_LOAD: return tr("Load this data?\n\n%0", "Savedata entry info").arg(std::forward<Args>(args)...);
 		case localized_string_id::CELL_SAVEDATA_OVERWRITE: return tr("Do you want to overwrite the saved data?\n\n%0", "Savedata entry info").arg(std::forward<Args>(args)...);
-		case localized_string_id::CELL_SAVEDATA_AUTOSAVE: return tr("Saving...");
-		case localized_string_id::CELL_SAVEDATA_AUTOLOAD: return tr("Loading...");
+		case localized_string_id::CELL_SAVEDATA_AUTOSAVE: return tr("Saving");
+		case localized_string_id::CELL_SAVEDATA_AUTOLOAD: return tr("Loading");
 		case localized_string_id::CELL_CROSS_CONTROLLER_MSG: return tr("Start [%0] on the PS Vita system.\nIf you have not installed [%0], go to [Remote Play] on the PS Vita system and start [Cross-Controller] from the LiveArea™ screen.", "Cross-Controller message").arg(std::forward<Args>(args)...);
 		case localized_string_id::CELL_CROSS_CONTROLLER_FW_MSG: return tr("If your system software version on the PS Vita system is earlier than 1.80, you must update the system software to the latest version.", "Cross-Controller firmware message");
 		case localized_string_id::CELL_NP_RECVMESSAGE_DIALOG_TITLE: return tr("Select Message", "RECVMESSAGE_DIALOG");

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1765,6 +1765,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	m_emu_settings->EnhanceCheckBox(ui->showPPUCompilationHint, emu_settings_type::ShowPPUCompilationHint);
 	SubscribeTooltip(ui->showPPUCompilationHint, tooltips.settings.show_ppu_compilation_hint);
 
+	m_emu_settings->EnhanceCheckBox(ui->showAutosaveAutoloadHint, emu_settings_type::ShowAutosaveAutoloadHint);
+	SubscribeTooltip(ui->showAutosaveAutoloadHint, tooltips.settings.show_autosave_autoload_hint);
+
 	m_emu_settings->EnhanceCheckBox(ui->pauseDuringHomeMenu, emu_settings_type::PauseDuringHomeMenu);
 	SubscribeTooltip(ui->pauseDuringHomeMenu, tooltips.settings.pause_during_home_menu);
 

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -2980,6 +2980,13 @@
                 </widget>
                </item>
                <item>
+                <widget class="QCheckBox" name="showAutosaveAutoloadHint">
+                 <property name="text">
+                  <string>Show autosave/autoload hint</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <widget class="QCheckBox" name="startGameFullscreen">
                  <property name="text">
                   <string>Start games in fullscreen mode</string>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -140,6 +140,7 @@ public:
 		const QString hide_mouse_on_idle           = tr("Hides the mouse cursor if no mouse movement is detected for the configured time.");
 		const QString show_shader_compilation_hint = tr("Shows 'Compiling shaders' hint using the native overlay.");
 		const QString show_ppu_compilation_hint    = tr("Shows 'Compiling PPU modules' hint using the native overlay.");
+		const QString show_autosave_autoload_hint  = tr("Shows autosave/autoload hint using the native overlay.");
 		const QString use_native_interface         = tr("Enables use of native HUD within the game window that can interact with game controllers.\nWhen disabled, regular Qt dialogs are used instead.\nCurrently, the on-screen keyboard only supports the English key layout.");
 		const QString pause_during_home_menu       = tr("When enabled, opening the home menu will also pause emulation.\nWhile most games pause themselves while the home menu is shown, some do not.\nIn that case it can be helpful to pause the emulation whenever the home menu is open.");
 


### PR DESCRIPTION
just added the GUI support to enable/disable the autosave/autoload hint. The option is present in the Config's `Emulator` tab and also in the ingame's `Home Menu->Settings->Overlays` menu (accessible by pressing on the PS button).
Applied also the review provided by Megamouse + minor cleanup (ordered queues and pin location enums)